### PR TITLE
Fix path to datacamp

### DIFF
--- a/Matplotlib/Matplotlib.md
+++ b/Matplotlib/Matplotlib.md
@@ -324,4 +324,4 @@ plt.show()
 ```
 ![alt-text](/img/advanced.png)
 
-Sources: [Datacamp](www.datacamp.com), [Official Docs](http://matplotlib.org/api/) and [Quandl](https://s3.amazonaws.com/quandl-static-content/Documents/Quandl+-+Pandas,+SciPy,+NumPy+Cheat+Sheet.pdf)
+Sources: [Datacamp](https://www.datacamp.com/), [Official Docs](http://matplotlib.org/api/) and [Quandl](https://s3.amazonaws.com/quandl-static-content/Documents/Quandl+-+Pandas,+SciPy,+NumPy+Cheat+Sheet.pdf)


### PR DESCRIPTION
In sources, the datacamp url redirects to Github subpage